### PR TITLE
Made so products include productCategory id

### DIFF
--- a/src/foobar/rest/serializers/product.py
+++ b/src/foobar/rest/serializers/product.py
@@ -9,6 +9,7 @@ class ProductSerializer(serializers.Serializer):
     description = serializers.CharField(allow_null=True)
     image = serializers.ImageField(allow_null=True)
     price = MoneyField(non_negative=True)
+    category = serializers.UUIDField(read_only=True, source='category.id')
     active = serializers.BooleanField(default=False)
     qty = serializers.IntegerField(read_only=True)
 
@@ -22,3 +23,4 @@ class ProductParamSerializer(serializers.Serializer):
 class ProductCategorySerializer(serializers.Serializer):
     id = serializers.UUIDField(read_only=True)
     name = serializers.CharField()
+    image = serializers.ImageField(allow_null=True)


### PR DESCRIPTION
Every product is placed in a category but the information were never passed with the product on a API-call, meaning you could never group them based on category.

The same issue was with the categories images.